### PR TITLE
Drag drop widget items

### DIFF
--- a/app/src/apiNougat/java/foundation/e/blisslauncher/core/Preferences.java
+++ b/app/src/apiNougat/java/foundation/e/blisslauncher/core/Preferences.java
@@ -2,14 +2,8 @@ package foundation.e.blisslauncher.core;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.graphics.Color;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
-import java.util.ArrayList;
-import java.util.Locale;
 
 import foundation.e.blisslauncher.core.utils.Constants;
 

--- a/app/src/apiOreo/java/foundation/e/blisslauncher/core/Preferences.java
+++ b/app/src/apiOreo/java/foundation/e/blisslauncher/core/Preferences.java
@@ -2,14 +2,8 @@ package foundation.e.blisslauncher.core;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.graphics.Color;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
-import java.util.ArrayList;
-import java.util.Locale;
 
 import foundation.e.blisslauncher.core.utils.Constants;
 

--- a/app/src/main/java/foundation/e/blisslauncher/core/customviews/RoundedWidgetView.java
+++ b/app/src/main/java/foundation/e/blisslauncher/core/customviews/RoundedWidgetView.java
@@ -32,6 +32,8 @@ public class RoundedWidgetView extends AppWidgetHostView {
     private boolean mChildrenFocused;
 
     private boolean activated = false;
+    private int originalContainerIndex = -1;
+    private int newContainerIndex = -1;
 
     public RoundedWidgetView(Context context) {
         super(context);
@@ -48,7 +50,6 @@ public class RoundedWidgetView extends AppWidgetHostView {
         stencilPath.reset();
         stencilPath.addRoundRect(0, 0, w, h, cornerRadius, cornerRadius, Path.Direction.CW);
         stencilPath.close();
-
     }
 
     @Override
@@ -160,5 +161,18 @@ public class RoundedWidgetView extends AppWidgetHostView {
 
     public boolean isWidgetActivated() {
         return activated;
+    }
+
+    public int getOriginalContainerIndex() {
+        return originalContainerIndex;
+    }
+    public void setOriginalContainerIndex(int index) {
+        originalContainerIndex = index;
+    }
+    public int getNewContainerIndex() {
+        return newContainerIndex;
+    }
+    public void setNewContainerIndex(int index) {
+        newContainerIndex = index;
     }
 }

--- a/app/src/main/java/foundation/e/blisslauncher/core/customviews/RoundedWidgetView.java
+++ b/app/src/main/java/foundation/e/blisslauncher/core/customviews/RoundedWidgetView.java
@@ -32,7 +32,6 @@ public class RoundedWidgetView extends AppWidgetHostView {
     private boolean mChildrenFocused;
 
     private boolean activated = false;
-    private int originalContainerIndex = -1;
     private int newContainerIndex = -1;
 
     public RoundedWidgetView(Context context) {
@@ -163,12 +162,6 @@ public class RoundedWidgetView extends AppWidgetHostView {
         return activated;
     }
 
-    public int getOriginalContainerIndex() {
-        return originalContainerIndex;
-    }
-    public void setOriginalContainerIndex(int index) {
-        originalContainerIndex = index;
-    }
     public int getNewContainerIndex() {
         return newContainerIndex;
     }

--- a/app/src/main/java/foundation/e/blisslauncher/features/accessibility/LockAccessibilityService.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/accessibility/LockAccessibilityService.java
@@ -5,7 +5,6 @@ import android.accessibilityservice.AccessibilityServiceInfo;
 import android.util.Log;
 import android.view.accessibility.AccessibilityEvent;
 
-import androidx.room.util.StringUtil;
 
 import java.util.Objects;
 

--- a/app/src/main/java/foundation/e/blisslauncher/features/launcher/LauncherActivity.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/launcher/LauncherActivity.java
@@ -432,18 +432,12 @@ public class LauncherActivity extends AppCompatActivity implements
 
             RoundedWidgetView widgetView = widgetManager.dequeMoveWidgetView();
             while (widgetView != null) {
-                RoundedWidgetView swapWidget = (RoundedWidgetView) widgetContainer.getChildAt(widgetView.getNewContainerIndex());
                 for (int i = 0; i < widgetContainer.getChildCount(); i++) {
                     if (widgetContainer.getChildAt(i) instanceof RoundedWidgetView) {
                         RoundedWidgetView appWidgetHostView =
                                 (RoundedWidgetView) widgetContainer.getChildAt(i);
-                        if (appWidgetHostView.getAppWidgetId() == swapWidget.getAppWidgetId()) {
+                        if (appWidgetHostView.getAppWidgetId() == widgetView.getAppWidgetId()) {
                             widgetContainer.removeViewAt(i);
-                            i--;
-                            DatabaseManager.getManager(this).removeWidget(swapWidget.getAppWidgetId());
-                        } else if (appWidgetHostView.getAppWidgetId() == widgetView.getAppWidgetId()) {
-                            widgetContainer.removeViewAt(i);
-                            i--;
                             DatabaseManager.getManager(this).removeWidget(widgetView.getAppWidgetId());
                         }
                     }
@@ -452,11 +446,6 @@ public class LauncherActivity extends AppCompatActivity implements
                     widgetContainer.addView(widgetView, widgetView.getNewContainerIndex());
                 else
                     widgetContainer.addView(widgetView);
-
-                if (widgetView.getOriginalContainerIndex() < widgetContainer.getChildCount())
-                    widgetContainer.addView(swapWidget, widgetView.getOriginalContainerIndex());
-                else
-                    widgetContainer.addView(swapWidget);
 
                 widgetView = widgetManager.dequeMoveWidgetView();
             }

--- a/app/src/main/java/foundation/e/blisslauncher/features/launcher/LauncherActivity.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/launcher/LauncherActivity.java
@@ -448,8 +448,16 @@ public class LauncherActivity extends AppCompatActivity implements
                         }
                     }
                 }
-                widgetContainer.addView(widgetView, widgetView.getNewContainerIndex());
-                widgetContainer.addView(swapWidget, widgetView.getOriginalContainerIndex());
+                if (widgetView.getNewContainerIndex() < widgetContainer.getChildCount())
+                    widgetContainer.addView(widgetView, widgetView.getNewContainerIndex());
+                else
+                    widgetContainer.addView(widgetView);
+
+                if (widgetView.getOriginalContainerIndex() < widgetContainer.getChildCount())
+                    widgetContainer.addView(swapWidget, widgetView.getOriginalContainerIndex());
+                else
+                    widgetContainer.addView(swapWidget);
+
                 widgetView = widgetManager.dequeMoveWidgetView();
             }
 
@@ -459,19 +467,23 @@ public class LauncherActivity extends AppCompatActivity implements
                 addWidgetToContainer(widgetView);
                 widgetView = widgetManager.dequeAddWidgetView();
             }
-            List<Integer> currentWidgetIds = new ArrayList<>();
-            for (int i = 0; i < widgetContainer.getChildCount(); i++) {
-                if (widgetContainer.getChildAt(i) instanceof RoundedWidgetView) {
-                    currentWidgetIds.add(((RoundedWidgetView) widgetContainer.getChildAt(i)).getAppWidgetId());
-                }
-            }
-            widgetManager.setCurrentWidgetIds(currentWidgetIds);
+            updateCurrentWidgetIds();
         }
     }
 
     private void addWidgetToContainer(RoundedWidgetView widgetView) {
         widgetView.setPadding(0, 0, 0, 0);
         widgetContainer.addView(widgetView);
+    }
+
+    private void updateCurrentWidgetIds() {
+        List<Integer> currentWidgetIds = new ArrayList<>();
+        for (int i = 0; i < widgetContainer.getChildCount(); i++) {
+            if (widgetContainer.getChildAt(i) instanceof RoundedWidgetView) {
+                currentWidgetIds.add(((RoundedWidgetView) widgetContainer.getChildAt(i)).getAppWidgetId());
+            }
+        }
+        WidgetManager.getInstance().setCurrentWidgetIds(currentWidgetIds);
     }
 
     @Override
@@ -1433,6 +1445,7 @@ public class LauncherActivity extends AppCompatActivity implements
                         }, Throwable::printStackTrace));
             }
         }
+        updateCurrentWidgetIds();
     }
 
     @Override

--- a/app/src/main/java/foundation/e/blisslauncher/features/launcher/LauncherActivity.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/launcher/LauncherActivity.java
@@ -441,14 +441,14 @@ public class LauncherActivity extends AppCompatActivity implements
             while (widgetView != null) {
                 for (int i = 0; i < widgetContainer.getChildCount(); i++) {
                     if (widgetContainer.getChildAt(i) instanceof RoundedWidgetView) {
-                        RoundedWidgetView appWidgetHostView =
-                                (RoundedWidgetView) widgetContainer.getChildAt(i);
+                        RoundedWidgetView appWidgetHostView = (RoundedWidgetView) widgetContainer.getChildAt(i);
                         if (appWidgetHostView.getAppWidgetId() == widgetView.getAppWidgetId()) {
                             widgetContainer.removeViewAt(i);
+                            addWidgetToContainer(widgetView, widgetView.getNewContainerIndex(), appWidgetHostView.getLayoutParams());
+                            break;
                         }
                     }
                 }
-                addWidgetToContainer(widgetView, widgetView.getNewContainerIndex());
                 widgetView = widgetManager.dequeMoveWidgetView();
             }
             updateCurrentWidgetIds();
@@ -456,9 +456,9 @@ public class LauncherActivity extends AppCompatActivity implements
     }
 
     private void addWidgetToContainer(RoundedWidgetView widgetView) {
-        addWidgetToContainer(widgetView, -1);
+        addWidgetToContainer(widgetView, -1, widgetView.getLayoutParams());
     }
-    private void addWidgetToContainer(RoundedWidgetView widgetView, int index) {
+    private void addWidgetToContainer(RoundedWidgetView widgetView, int index, ViewGroup.LayoutParams layoutParams) {
         for (int i = 0; i < widgetContainer.getChildCount(); i++) {
             if (widgetContainer.getChildAt(i) instanceof RoundedWidgetView) {
                 RoundedWidgetView appWidgetHostView = (RoundedWidgetView) widgetContainer.getChildAt(i);
@@ -466,6 +466,7 @@ public class LauncherActivity extends AppCompatActivity implements
                     return;
             }
         }
+        widgetView.setLayoutParams(layoutParams);
         widgetView.setPadding(0, 0, 0, 0);
         widgetContainer.addView(widgetView, index);
     }

--- a/app/src/main/java/foundation/e/blisslauncher/features/launcher/LauncherActivity.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/launcher/LauncherActivity.java
@@ -459,6 +459,13 @@ public class LauncherActivity extends AppCompatActivity implements
                 addWidgetToContainer(widgetView);
                 widgetView = widgetManager.dequeAddWidgetView();
             }
+            List<Integer> currentWidgetIds = new ArrayList<>();
+            for (int i = 0; i < widgetContainer.getChildCount(); i++) {
+                if (widgetContainer.getChildAt(i) instanceof RoundedWidgetView) {
+                    currentWidgetIds.add(((RoundedWidgetView) widgetContainer.getChildAt(i)).getAppWidgetId());
+                }
+            }
+            widgetManager.setCurrentWidgetIds(currentWidgetIds);
         }
     }
 

--- a/app/src/main/java/foundation/e/blisslauncher/features/launcher/LauncherActivity.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/launcher/LauncherActivity.java
@@ -430,7 +430,14 @@ public class LauncherActivity extends AppCompatActivity implements
                 id = widgetManager.dequeRemoveId();
             }
 
-            RoundedWidgetView widgetView = widgetManager.dequeMoveWidgetView();
+            RoundedWidgetView widgetView = widgetManager.dequeAddWidgetView();
+            while (widgetView != null) {
+                widgetView = WidgetViewBuilder.create(this, widgetView);
+                addWidgetToContainer(widgetView);
+                widgetView = widgetManager.dequeAddWidgetView();
+            }
+
+            widgetView = widgetManager.dequeMoveWidgetView();
             while (widgetView != null) {
                 for (int i = 0; i < widgetContainer.getChildCount(); i++) {
                     if (widgetContainer.getChildAt(i) instanceof RoundedWidgetView) {
@@ -438,31 +445,29 @@ public class LauncherActivity extends AppCompatActivity implements
                                 (RoundedWidgetView) widgetContainer.getChildAt(i);
                         if (appWidgetHostView.getAppWidgetId() == widgetView.getAppWidgetId()) {
                             widgetContainer.removeViewAt(i);
-                            DatabaseManager.getManager(this).removeWidget(widgetView.getAppWidgetId());
                         }
                     }
                 }
-                if (widgetView.getNewContainerIndex() < widgetContainer.getChildCount())
-                    widgetContainer.addView(widgetView, widgetView.getNewContainerIndex());
-                else
-                    widgetContainer.addView(widgetView);
-
+                addWidgetToContainer(widgetView, widgetView.getNewContainerIndex());
                 widgetView = widgetManager.dequeMoveWidgetView();
-            }
-
-            widgetView = widgetManager.dequeAddWidgetView();
-            while (widgetView != null) {
-                widgetView = WidgetViewBuilder.create(this, widgetView);
-                addWidgetToContainer(widgetView);
-                widgetView = widgetManager.dequeAddWidgetView();
             }
             updateCurrentWidgetIds();
         }
     }
 
     private void addWidgetToContainer(RoundedWidgetView widgetView) {
+        addWidgetToContainer(widgetView, -1);
+    }
+    private void addWidgetToContainer(RoundedWidgetView widgetView, int index) {
+        for (int i = 0; i < widgetContainer.getChildCount(); i++) {
+            if (widgetContainer.getChildAt(i) instanceof RoundedWidgetView) {
+                RoundedWidgetView appWidgetHostView = (RoundedWidgetView) widgetContainer.getChildAt(i);
+                if (appWidgetHostView.getAppWidgetId() == widgetView.getAppWidgetId())
+                    return;
+            }
+        }
         widgetView.setPadding(0, 0, 0, 0);
-        widgetContainer.addView(widgetView);
+        widgetContainer.addView(widgetView, index);
     }
 
     private void updateCurrentWidgetIds() {

--- a/app/src/main/java/foundation/e/blisslauncher/features/widgets/AddedWidgetsAdapter.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/widgets/AddedWidgetsAdapter.java
@@ -45,7 +45,7 @@ public class AddedWidgetsAdapter extends
                     if (position != RecyclerView.NO_POSITION) {
                         Widget widget = mAppWidgetProviderInfos.get(position);
                         mAppWidgetProviderInfos.remove(position);
-                        mOnActionClickListener.removeWidget(widget.id);
+                        mOnActionClickListener.removeWidget(widget.id, position);
                         notifyItemRemoved(position);
                     }
                 });
@@ -84,6 +84,6 @@ public class AddedWidgetsAdapter extends
     }
 
     interface OnActionClickListener {
-        void removeWidget(int id);
+        void removeWidget(int id, int position);
     }
 }

--- a/app/src/main/java/foundation/e/blisslauncher/features/widgets/AddedWidgetsAdapter.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/widgets/AddedWidgetsAdapter.java
@@ -68,6 +68,9 @@ public class AddedWidgetsAdapter extends
         this.mAppWidgetProviderInfos = appWidgetProviderInfos;
         notifyDataSetChanged();
     }
+    public List<Widget> getAppWidgetProviderInfos() {
+        return mAppWidgetProviderInfos;
+    }
 
     public static class WidgetsViewHolder extends RecyclerView.ViewHolder {
 

--- a/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetItemTouchHelperCallback.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetItemTouchHelperCallback.java
@@ -50,7 +50,6 @@ public class WidgetItemTouchHelperCallback extends ItemTouchHelper.Callback {
             Widget widget = items.get(toPosition);
             RoundedWidgetView hostView = (RoundedWidgetView) widgetHost.createView(
                     applicationContext, widget.id, widget.info);
-            hostView.setOriginalContainerIndex(fromPosition);
             hostView.setNewContainerIndex(toPosition);
             WidgetManager.getInstance().enqueueMoveWidget(hostView);
             dragFrom = -1;

--- a/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetItemTouchHelperCallback.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetItemTouchHelperCallback.java
@@ -15,13 +15,11 @@ import foundation.e.blisslauncher.core.customviews.WidgetHost;
 public class WidgetItemTouchHelperCallback extends ItemTouchHelper.Callback {
     private int dragFrom = -1;
     private final AddedWidgetsAdapter adapter;
-    private final List<Widget> items;
     private final WidgetHost widgetHost;
     private final Context applicationContext;
 
-    public WidgetItemTouchHelperCallback(AddedWidgetsAdapter adapter, List<Widget> items, WidgetHost widgetHost, Context applicationContext) {
+    public WidgetItemTouchHelperCallback(AddedWidgetsAdapter adapter, WidgetHost widgetHost, Context applicationContext) {
         this.adapter = adapter;
-        this.items = items;
         this.widgetHost = widgetHost;
         this.applicationContext = applicationContext;
     }
@@ -39,6 +37,7 @@ public class WidgetItemTouchHelperCallback extends ItemTouchHelper.Callback {
 
         int fromPosition = viewHolder.getAdapterPosition();
         int toPosition = target.getAdapterPosition();
+        List<Widget> items = adapter.getAppWidgetProviderInfos();
 
         if (dragFrom == -1)
             dragFrom = fromPosition;
@@ -46,7 +45,7 @@ public class WidgetItemTouchHelperCallback extends ItemTouchHelper.Callback {
         if (toPosition < 0)
             toPosition = 0;
 
-        if (dragFrom != toPosition && reallyMoved(dragFrom, toPosition)) {
+        if (dragFrom != toPosition && reallyMoved(dragFrom, toPosition, items)) {
             Widget widget = items.get(toPosition);
             RoundedWidgetView hostView = (RoundedWidgetView) widgetHost.createView(
                     applicationContext, widget.id, widget.info);
@@ -64,11 +63,12 @@ public class WidgetItemTouchHelperCallback extends ItemTouchHelper.Callback {
 
     }
 
-    private boolean reallyMoved(int dragFrom, int dragTo) {
+    private boolean reallyMoved(int dragFrom, int dragTo, List<Widget> items) {
         if (dragFrom < 0 || dragTo >= items.size())
             return false;
 
         Collections.swap(items, dragFrom, dragTo);
+        Collections.swap(WidgetManager.getInstance().getCurrentWidgetIds(), dragFrom, dragTo);
         return true;
     }
 }

--- a/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetItemTouchHelperCallback.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetItemTouchHelperCallback.java
@@ -46,18 +46,17 @@ public class WidgetItemTouchHelperCallback extends ItemTouchHelper.Callback {
         if (toPosition < 0)
             toPosition = 0;
 
-        if (reallyMoved(dragFrom, toPosition)) {
-            adapter.notifyItemMoved(viewHolder.getAdapterPosition(), target.getAdapterPosition());
-            adapter.setAppWidgetProviderInfos(items);
+        if (dragFrom != toPosition && reallyMoved(dragFrom, toPosition)) {
             Widget widget = items.get(toPosition);
             RoundedWidgetView hostView = (RoundedWidgetView) widgetHost.createView(
                     applicationContext, widget.id, widget.info);
             hostView.setOriginalContainerIndex(fromPosition);
             hostView.setNewContainerIndex(toPosition);
             WidgetManager.getInstance().enqueueMoveWidget(hostView);
+            dragFrom = -1;
         }
 
-        dragFrom = -1;
+        adapter.notifyItemMoved(fromPosition, toPosition);
         return true;
     }
 

--- a/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetItemTouchHelperCallback.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetItemTouchHelperCallback.java
@@ -1,0 +1,69 @@
+/*
+  Credit to Gopal Awasthi
+  https://medium.com/@gopalawasthi383/android-recyclerview-drag-and-drop-a3f227cdb641
+ */
+package foundation.e.blisslauncher.features.widgets;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.Collections;
+import java.util.List;
+
+public class WidgetItemTouchHelperCallback extends ItemTouchHelper.Callback {
+    private int dragFrom = -1;
+    private final AddedWidgetsAdapter adapter;
+    private final List<Widget> items;
+
+    public WidgetItemTouchHelperCallback(AddedWidgetsAdapter adapter, List<Widget> items) {
+        this.adapter = adapter;
+        this.items = items;
+    }
+
+    @Override
+    public int getMovementFlags(@NonNull RecyclerView recyclerView, @NonNull RecyclerView.ViewHolder viewHolder) {
+        int dragFlags = ItemTouchHelper.UP | ItemTouchHelper.DOWN;
+        return makeMovementFlags(dragFlags,0);
+    }
+
+    @Override
+    public boolean onMove(@NonNull RecyclerView recyclerView, @NonNull RecyclerView.ViewHolder viewHolder, @NonNull RecyclerView.ViewHolder target) {
+        // get the viewHolder's and target's positions in your adapter data, swap them
+        if (viewHolder.getItemViewType() != target.getItemViewType())
+            return false;
+
+        int fromPosition = viewHolder.getAdapterPosition();
+        int toPosition = target.getAdapterPosition();
+
+        if (dragFrom == -1)
+            dragFrom =  fromPosition;
+
+        if (dragFrom != -1 && toPosition != -1 && dragFrom != toPosition) {
+            reallyMoved(dragFrom, toPosition);
+            dragFrom = -1;
+        }
+
+        // and notify the adapter that its dataset has changed
+        adapter.notifyItemMoved(viewHolder.getAdapterPosition(), target.getAdapterPosition());
+        //nestedScrollView.requestDisallowInterceptTouchEvent(false);
+        //recyclerView.setNestedScrollingEnabled(false);
+
+        return true;
+    }
+
+    @Override
+    public void onSwiped(@NonNull RecyclerView.ViewHolder viewHolder, int direction) {
+
+    }
+
+    private void reallyMoved(int dragFrom, int dragTo) {
+        if (dragFrom <= 0 || dragTo >= items.size())
+            return;
+
+        if (dragTo < 1)
+            dragTo = 1;
+
+        Collections.swap(items, dragFrom-1, dragTo-1);
+    }
+}

--- a/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetManager.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetManager.java
@@ -10,7 +10,7 @@ import foundation.e.blisslauncher.core.customviews.RoundedWidgetView;
 public class WidgetManager {
     private static final WidgetManager ourInstance = new WidgetManager();
 
-    private int[] currentWidgetIds;
+    private int[] currentWidgetIds = new int[0];
     private Queue<Integer> removeWidgetIds = new LinkedList<>();
     private Queue<RoundedWidgetView> addWidgetViews = new LinkedList<>();
     private Queue<RoundedWidgetView> moveWidgetViews = new LinkedList<>();

--- a/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetManager.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetManager.java
@@ -2,6 +2,7 @@ package foundation.e.blisslauncher.features.widgets;
 
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Queue;
 
 import foundation.e.blisslauncher.core.customviews.RoundedWidgetView;
@@ -9,6 +10,7 @@ import foundation.e.blisslauncher.core.customviews.RoundedWidgetView;
 public class WidgetManager {
     private static final WidgetManager ourInstance = new WidgetManager();
 
+    private int[] currentWidgetIds;
     private Queue<Integer> removeWidgetIds = new LinkedList<>();
     private Queue<RoundedWidgetView> addWidgetViews = new LinkedList<>();
     private Queue<RoundedWidgetView> moveWidgetViews = new LinkedList<>();
@@ -64,5 +66,16 @@ public class WidgetManager {
 
     public RoundedWidgetView dequeMoveWidgetView() {
         return moveWidgetViews.poll();
+    }
+
+    public int[] getCurrentWidgetIds() {
+        return currentWidgetIds;
+    }
+    public void setCurrentWidgetIds(List<Integer> widgetIds) {
+        int[] newWidgetIds = new int[widgetIds.size()];
+        for (int i = 0; i < widgetIds.size(); i++) {
+            newWidgetIds[i] = widgetIds.get(i);
+        }
+        currentWidgetIds = newWidgetIds;
     }
 }

--- a/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetManager.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetManager.java
@@ -11,6 +11,7 @@ public class WidgetManager {
 
     private Queue<Integer> removeWidgetIds = new LinkedList<>();
     private Queue<RoundedWidgetView> addWidgetViews = new LinkedList<>();
+    private Queue<RoundedWidgetView> moveWidgetViews = new LinkedList<>();
 
     public static WidgetManager getInstance() {
         return ourInstance;
@@ -33,8 +34,24 @@ public class WidgetManager {
         removeWidgetIds.add(id);
     }
 
+    public void enqueueRemoveId(int id, int index) {
+        enqueueRemoveId(id);
+        for (RoundedWidgetView view : moveWidgetViews) {
+            if (view.getNewContainerIndex() == index)
+                moveWidgetViews.remove(view);
+            if (view.getNewContainerIndex() > index)
+                view.setNewContainerIndex(view.getNewContainerIndex()-1);
+            if (view.getOriginalContainerIndex() > index)
+                view.setOriginalContainerIndex(view.getOriginalContainerIndex()-1);
+        }
+    }
+
     public void enqueueAddWidget(RoundedWidgetView view) {
         addWidgetViews.add(view);
+    }
+
+    public void enqueueMoveWidget(RoundedWidgetView view) {
+        moveWidgetViews.add(view);
     }
 
     public Integer dequeRemoveId() {
@@ -43,5 +60,9 @@ public class WidgetManager {
 
     public RoundedWidgetView dequeAddWidgetView() {
         return addWidgetViews.poll();
+    }
+
+    public RoundedWidgetView dequeMoveWidgetView() {
+        return moveWidgetViews.poll();
     }
 }

--- a/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetManager.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetManager.java
@@ -1,5 +1,6 @@
 package foundation.e.blisslauncher.features.widgets;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -10,7 +11,7 @@ import foundation.e.blisslauncher.core.customviews.RoundedWidgetView;
 public class WidgetManager {
     private static final WidgetManager ourInstance = new WidgetManager();
 
-    private int[] currentWidgetIds = new int[0];
+    private List<Integer> currentWidgetIds = new ArrayList<>();
     private Queue<Integer> removeWidgetIds = new LinkedList<>();
     private Queue<RoundedWidgetView> addWidgetViews = new LinkedList<>();
     private Queue<RoundedWidgetView> moveWidgetViews = new LinkedList<>();
@@ -70,14 +71,10 @@ public class WidgetManager {
         return moveWidgetViews.poll();
     }
 
-    public int[] getCurrentWidgetIds() {
+    public List<Integer> getCurrentWidgetIds() {
         return currentWidgetIds;
     }
     public void setCurrentWidgetIds(List<Integer> widgetIds) {
-        int[] newWidgetIds = new int[widgetIds.size()];
-        for (int i = 0; i < widgetIds.size(); i++) {
-            newWidgetIds[i] = widgetIds.get(i);
-        }
-        currentWidgetIds = newWidgetIds;
+        currentWidgetIds = widgetIds;
     }
 }

--- a/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetManager.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetManager.java
@@ -43,8 +43,6 @@ public class WidgetManager {
                 moveWidgetViews.remove(view);
             if (view.getNewContainerIndex() > index)
                 view.setNewContainerIndex(view.getNewContainerIndex()-1);
-            if (view.getOriginalContainerIndex() > index)
-                view.setOriginalContainerIndex(view.getOriginalContainerIndex()-1);
         }
     }
 
@@ -53,7 +51,11 @@ public class WidgetManager {
     }
 
     public void enqueueMoveWidget(RoundedWidgetView view) {
-        moveWidgetViews.add(view);
+        RoundedWidgetView contained = moveWidgetViews.stream().filter(v -> v.getAppWidgetId() == view.getAppWidgetId()).findFirst().orElse(null);
+        if (contained == null)
+            moveWidgetViews.add(view);
+        else
+            contained.setNewContainerIndex(view.getNewContainerIndex());
     }
 
     public Integer dequeRemoveId() {

--- a/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetsActivity.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetsActivity.java
@@ -10,6 +10,7 @@ import android.util.DisplayMetrics;
 import android.widget.Toast;
 
 import androidx.recyclerview.widget.DividerItemDecoration;
+import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -25,7 +26,7 @@ import foundation.e.blisslauncher.core.customviews.WidgetHost;
 public class WidgetsActivity extends Activity implements AddedWidgetsAdapter.OnActionClickListener {
 
     private AddedWidgetsAdapter mAddedWidgetsAdapter;
-
+    private RecyclerView mAddedWidgetsRecyclerView;
     private AppWidgetManager mAppWidgetManager;
     private WidgetHost mAppWidgetHost;
 
@@ -40,18 +41,18 @@ public class WidgetsActivity extends Activity implements AddedWidgetsAdapter.OnA
         mAppWidgetManager = BlissLauncher.getApplication(this).getAppWidgetManager();
         mAppWidgetHost = BlissLauncher.getApplication(this).getAppWidgetHost();
 
-        RecyclerView addedWidgets = findViewById(R.id.added_widgets_recycler_view);
-        addedWidgets.setLayoutManager(new LinearLayoutManager(this));
-        addedWidgets.setHasFixedSize(false);
-        addedWidgets.setNestedScrollingEnabled(false);
-        addedWidgets.addItemDecoration(
+        mAddedWidgetsRecyclerView = findViewById(R.id.added_widgets_recycler_view);
+        mAddedWidgetsRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+        mAddedWidgetsRecyclerView.setHasFixedSize(false);
+        mAddedWidgetsRecyclerView.setNestedScrollingEnabled(false);
+        mAddedWidgetsRecyclerView.addItemDecoration(
                 new DividerItemDecoration(this, DividerItemDecoration.VERTICAL));
 
         DisplayMetrics metrics = new DisplayMetrics();
         getWindowManager().getDefaultDisplay().getMetrics(metrics);
 
         mAddedWidgetsAdapter = new AddedWidgetsAdapter(this, metrics.densityDpi);
-        addedWidgets.setAdapter(mAddedWidgetsAdapter);
+        mAddedWidgetsRecyclerView.setAdapter(mAddedWidgetsAdapter);
 
         refreshRecyclerView();
 
@@ -74,6 +75,9 @@ public class WidgetsActivity extends Activity implements AddedWidgetsAdapter.OnA
             }
         }
         mAddedWidgetsAdapter.setAppWidgetProviderInfos(widgets);
+
+        new ItemTouchHelper(new WidgetItemTouchHelperCallback(mAddedWidgetsAdapter, widgets))
+                .attachToRecyclerView(mAddedWidgetsRecyclerView);
     }
 
     @Override

--- a/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetsActivity.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetsActivity.java
@@ -17,6 +17,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import foundation.e.blisslauncher.BlissLauncher;
 import foundation.e.blisslauncher.R;
@@ -65,7 +66,7 @@ public class WidgetsActivity extends Activity implements AddedWidgetsAdapter.OnA
         List<Widget> widgets = new ArrayList<>();
         int[] widgetIds = mAppWidgetHost.getAppWidgetIds();
         Arrays.sort(widgetIds);
-        if (WidgetManager.getInstance().getCurrentWidgetIds() != null)
+        if (WidgetManager.getInstance().getCurrentWidgetIds().length > 0)
             widgetIds = WidgetManager.getInstance().getCurrentWidgetIds();
 
         for (int id : widgetIds) {
@@ -99,6 +100,10 @@ public class WidgetsActivity extends Activity implements AddedWidgetsAdapter.OnA
         pickIntent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId);
         addEmptyData(pickIntent);
         startActivityForResult(pickIntent, REQUEST_PICK_APPWIDGET);
+        List<Integer> currentWidgetIds = Arrays.stream(WidgetManager.getInstance().getCurrentWidgetIds())
+                .boxed().collect(Collectors.toList());
+        currentWidgetIds.add(appWidgetId);
+        WidgetManager.getInstance().setCurrentWidgetIds(currentWidgetIds);
     }
 
     void addEmptyData(Intent pickIntent) {

--- a/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetsActivity.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetsActivity.java
@@ -70,7 +70,7 @@ public class WidgetsActivity extends Activity implements AddedWidgetsAdapter.OnA
     private void refreshRecyclerView() {
         int[] widgetIds = mAppWidgetHost.getAppWidgetIds();
         Arrays.sort(widgetIds);
-        if (WidgetManager.getInstance().getCurrentWidgetIds().size() == widgetIds.length) {
+        if (WidgetManager.getInstance().getCurrentWidgetIds().size() > 0) {
             widgetIds = WidgetManager.getInstance().getCurrentWidgetIds().stream().mapToInt(i -> i).toArray();
             widgets = new ArrayList<>();
         } else {

--- a/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetsActivity.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetsActivity.java
@@ -65,6 +65,9 @@ public class WidgetsActivity extends Activity implements AddedWidgetsAdapter.OnA
         List<Widget> widgets = new ArrayList<>();
         int[] widgetIds = mAppWidgetHost.getAppWidgetIds();
         Arrays.sort(widgetIds);
+        if (WidgetManager.getInstance().getCurrentWidgetIds() != null)
+            widgetIds = WidgetManager.getInstance().getCurrentWidgetIds();
+
         for (int id : widgetIds) {
             AppWidgetProviderInfo appWidgetInfo = mAppWidgetManager.getAppWidgetInfo(id);
             if (appWidgetInfo != null) {
@@ -75,8 +78,6 @@ public class WidgetsActivity extends Activity implements AddedWidgetsAdapter.OnA
             }
         }
         mAddedWidgetsAdapter.setAppWidgetProviderInfos(widgets);
-
-        //TODO - keep sort order of widgets
         new ItemTouchHelper(new WidgetItemTouchHelperCallback(mAddedWidgetsAdapter, widgets, mAppWidgetHost, getApplicationContext()))
                 .attachToRecyclerView(mAddedWidgetsRecyclerView);
     }

--- a/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetsActivity.java
+++ b/app/src/main/java/foundation/e/blisslauncher/features/widgets/WidgetsActivity.java
@@ -76,11 +76,17 @@ public class WidgetsActivity extends Activity implements AddedWidgetsAdapter.OnA
         }
         mAddedWidgetsAdapter.setAppWidgetProviderInfos(widgets);
 
-        new ItemTouchHelper(new WidgetItemTouchHelperCallback(mAddedWidgetsAdapter, widgets))
+        //TODO - keep sort order of widgets
+        new ItemTouchHelper(new WidgetItemTouchHelperCallback(mAddedWidgetsAdapter, widgets, mAppWidgetHost, getApplicationContext()))
                 .attachToRecyclerView(mAddedWidgetsRecyclerView);
     }
 
     @Override
+    public void removeWidget(int id, int index) {
+        mAppWidgetHost.deleteAppWidgetId(id);
+        WidgetManager.getInstance().enqueueRemoveId(id, index);
+    }
+
     public void removeWidget(int id) {
         mAppWidgetHost.deleteAppWidgetId(id);
         WidgetManager.getInstance().enqueueRemoveId(id);


### PR DESCRIPTION
You can now swap the order of widgets within the add widgets recycler view. This ordering then gets passed to the home-screen widgets page.

Previously if you wanted to swap the order of widgets you had to remove and re-add in the order you wanted which was a hassle. 

**Scenarios Manually Tested:**

Setup: Start with 3 widgets
- Swap first with last
- Swap last with first
- Swap middle with first
- Swap middle with last
- Swap first with last, then swap last with middle
- Add an additional widget, swap it with the first.
- Add an additional widget, swap it with the first. Add another widget, swap it with the first. 
- Add an additional widget, swap it with the second. Remove the first.
- Add two additional widgets. Swap to second and fourth. Remove all of the original widgets.

**Note** There was a slight issue with the Digital Clock widget. 
It would fail the "_Add an additional widget, swap with first_" test scenario. The widget would not appear in the home-screen, however if you just added the widget it would add as normal and could be swapped after.
I had no issues with any of the other widget types, so it seems to be specific to the Digital Clock and is not a breaking problem.  